### PR TITLE
Update zcl_abapgit_object_form.clas.abap

### DIFF
--- a/src/objects/zcl_abapgit_object_form.clas.abap
+++ b/src/objects/zcl_abapgit_object_form.clas.abap
@@ -254,7 +254,17 @@ CLASS zcl_abapgit_object_form IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD _build_extra_from_header.
-    r_result = c_objectname_tdlines && '_' && ls_header-tdspras.
+
+    DATA: lv_tdspras type laiso.
+
+    CALL FUNCTION 'CONVERSION_EXIT_ISOLA_OUTPUT'
+      EXPORTING
+        input  = ls_header-tdspras
+      IMPORTING
+        output = lv_tdspras.
+
+    r_result = c_objectname_tdlines && '_' && lv_tdspras.
+    
   ENDMETHOD.
 
   METHOD _get_last_changes.


### PR DESCRIPTION
Old code generate error of duplicity because SPRAS is case sensitive, but the name of files not.

New code use the 2-caracteres code for language. 

Examples (T002):
- SPRAS: 'C' -> LAISO: CS -> 'Czech'
- SPRAS: 'c' -> LAISO: CA -> 'Catalan'